### PR TITLE
Show error notication on metod call failure

### DIFF
--- a/src/lib/tunedmanager/tunedmanager.cpp
+++ b/src/lib/tunedmanager/tunedmanager.cpp
@@ -27,18 +27,19 @@ bool TunedManager::IsProfileModeAuto()
     return ProfileMode.Mode == "auto";
 }
 
-bool TunedManager::SetProfileModeAuto()
+QTunedResult TunedManager::SetProfileModeAuto()
 {
     QDBusInterface DBusInterface(BusName, BusPath, BusInterface, DBusInstance);
-    QDBusReply<void> DBusReply = DBusInterface.call(BusMethodNameAutoProfile);
-    return DBusReply.isValid();
+    QDBusReply<QTunedResult> DBusReply = DBusInterface.call(BusMethodNameAutoProfile);
+    return DBusReply.value();
 }
 
-bool TunedManager::SetActiveProfile(const QString& Profile)
+QTunedResult TunedManager::SetActiveProfile(const QString& Profile)
 {
     QDBusInterface DBusInterface(BusName, BusPath, BusInterface, DBusInstance);
-    QDBusReply<void> DBusReply = DBusInterface.call(BusMethodNameSwitchProfile, Profile);
-    return DBusReply.isValid();
+    QDBusReply<QTunedResult> DBusReply = DBusInterface.call(BusMethodNameSwitchProfile, Profile);
+    QTunedResult result = DBusReply.value();
+    return result;
 }
 
 QTunedProfileList TunedManager::GetAvailableProfiles2()
@@ -63,6 +64,8 @@ TunedManager::TunedManager(QObject *parent) : QObject(parent)
         qDBusRegisterMetaType<QTunedProfileList>();
         qRegisterMetaType<QTunedProfileMode>("QTunedProfileMode");
         qDBusRegisterMetaType<QTunedProfileMode>();
+        qRegisterMetaType<QTunedResult>("QTunedResult");
+        qDBusRegisterMetaType<QTunedResult>();
         QDBusConnection::systemBus().connect(BusName, BusPath, BusInterface, BusSignalNameProfileChanged, this, SLOT(ProfileChangedEvent(const QString&, const bool, const QString&)));
     }
 }

--- a/src/lib/tunedmanager/tunedmanager.h
+++ b/src/lib/tunedmanager/tunedmanager.h
@@ -19,8 +19,8 @@ public:
     QTunedProfileList GetAvailableProfiles2();
     QTunedProfileMode GetProfileMode();
     bool IsProfileModeAuto();
-    bool SetProfileModeAuto();
-    bool SetActiveProfile(const QString&);
+    QTunedResult SetProfileModeAuto();
+    QTunedResult SetActiveProfile(const QString&);
 private:
     const QString BusName = "com.redhat.tuned";
     const QString BusPath = "/Tuned";

--- a/src/lib/tunedtypes/tunedtypes.cpp
+++ b/src/lib/tunedtypes/tunedtypes.cpp
@@ -39,3 +39,23 @@ const QDBusArgument& operator >>(const QDBusArgument& argument, QTunedProfileMod
 
     return argument;
 }
+
+QDBusArgument& operator <<(QDBusArgument& argument, const QTunedResult& result)
+{
+    argument.beginStructure();
+    argument << result.Success;
+    argument << result.Message;
+    argument.endStructure();
+
+    return argument;
+}
+
+const QDBusArgument& operator >>(const QDBusArgument& argument, QTunedResult& result)
+{
+    argument.beginStructure();
+    argument >> result.Success;
+    argument >> result.Message;
+    argument.endStructure();
+
+    return argument;
+}

--- a/src/lib/tunedtypes/tunedtypes.h
+++ b/src/lib/tunedtypes/tunedtypes.h
@@ -27,4 +27,15 @@ struct QTunedProfileMode
 };
 Q_DECLARE_METATYPE(QTunedProfileMode)
 
+struct QTunedResult
+{
+    bool Success;
+    QString Message;
+    QTunedResult() : Success(), Message() {}
+    operator bool() { return Success; }
+    friend QDBusArgument &operator<<(QDBusArgument &argument, const QTunedResult &arg);
+    friend const QDBusArgument &operator>>(const QDBusArgument &argument, QTunedResult &arg);
+};
+Q_DECLARE_METATYPE(QTunedResult)
+
 #endif // TUNEDTYPES_H

--- a/src/tray/trayicon/trayicon.cpp
+++ b/src/tray/trayicon/trayicon.cpp
@@ -61,7 +61,7 @@ void TrayIcon::profileChangedEvent(const QString& profile, const bool result, co
         if (profileAction)
         {
             profileAction -> setChecked(true);
-            trayIcon -> showMessage(tr("Profile switched"), QString(tr("The active profile was successfully switched to %1.")).arg(profile), QSystemTrayIcon::Information);
+            trayIcon -> showMessage(tr("Profile switched"), QString(tr("The active profile was switched to %1.")).arg(profile), QSystemTrayIcon::Information);
         }
     }
     else
@@ -119,21 +119,25 @@ void TrayIcon::profileAutoSelectedEvent(bool modeAuto)
 {
     if (modeAuto)
     {
-        if (!tunedManager -> SetProfileModeAuto())
-            trayIcon -> showMessage(tr("Auto profile"), tr("Failed to send the D-Bus event!"), QSystemTrayIcon::Critical);
-        else
+        QTunedResult result = tunedManager -> SetProfileModeAuto();
+        if (result.Success)
             autoProfile -> setDisabled(true);
+        else
+            trayIcon -> showMessage(tr("Auto profile"), tr("Failed set auto-select profile: %1").arg(result.Message), QSystemTrayIcon::Critical);
     }
 }
 
 void TrayIcon::profileSelectedEvent(QAction* action)
 {
-    if (!tunedManager -> SetActiveProfile(action -> data().toString()))
-        trayIcon -> showMessage(tr("Profile change"), tr("Failed to send the D-Bus event!"), QSystemTrayIcon::Critical);
-    else
+    QTunedResult result = tunedManager -> SetActiveProfile(action -> data().toString());
+    if (result.Success)
     {
         autoProfile -> setChecked(false);
         autoProfile -> setDisabled(false);
+    }
+    else
+    {
+        trayIcon -> showMessage(tr("Switch profile"), tr("Failed to switch profile: %1").arg(result.Message), QSystemTrayIcon::Critical);
     }
 }
 


### PR DESCRIPTION
Tuned returns success status with message from `switch_profile` and `auto_profile` methods. We should check this status, too, not only dbus call success, and show error message if Tuned reported back unsuccessful result.