### PR TITLE
Enabled remote assets verification for XDG metainfo validator

### DIFF
--- a/assets/CMakeLists.txt
+++ b/assets/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 if (BUILD_TESTS)
     add_test(NAME test-desktop COMMAND ${DesktopFileValidate_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}.desktop")
-    add_test(NAME test-metainfo COMMAND ${AppstreamUtil_EXECUTABLE} validate --nonet "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}.metainfo.xml")
+    add_test(NAME test-metainfo COMMAND ${AppstreamUtil_EXECUTABLE} validate "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}.metainfo.xml")
 endif()
 
 configure_file("metainfo/${CMAKE_PROJECT_NAME}.metainfo.xml.in" "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}.metainfo.xml" @ONLY)


### PR DESCRIPTION
Describe your changes below:

Enabled remote assets verification for XDG metainfo validator.