### PR TITLE
Switched various methods to use compile-time strings allocation

### DIFF
--- a/src/app/mainwindow/mainwindow.cpp
+++ b/src/app/mainwindow/mainwindow.cpp
@@ -159,7 +159,7 @@ void MainWindow::loadSettings()
 void MainWindow::saveSettings()
 {
     QSettings settings;
-    settings.beginGroup("widget");
+    settings.beginGroup(QStringLiteral("widget"));
     settings.setValue(QStringLiteral("geometry"), saveGeometry());
     settings.setValue(QStringLiteral("windowState"), saveState());
     settings.endGroup();


### PR DESCRIPTION
Describe your changes below:

Switched various methods to use compile-time strings allocation.